### PR TITLE
Remove module index

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -52,6 +52,5 @@ Indices and tables
 ==================
 
 * :ref:`genindex`
-* :ref:`modindex`
 * :ref:`search`
 


### PR DESCRIPTION
Remove the module index since it wasn't displaying correctly and this
documentation project has no python modules.