### PR TITLE
Sphinx 3, code block captions, _static, alabaster theme

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -101,7 +101,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'alabaster'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/source/directory/sphinx.rst
+++ b/source/directory/sphinx.rst
@@ -265,6 +265,24 @@ bash and python.
   for i in range(10):
       print(i)
 
+Captions
+^^^^^^^^
+
+Now in Sphinx 1.3, captions can be added to code blocks as well:
+
+.. code-block:: rst
+
+  .. code-block:: python
+     :caption: this.py
+     :name: this-py
+
+     print('Explicit is better than implicit.')
+
+.. code-block:: python
+   :caption: this.py
+   :name: this-py
+
+   print('Explicit is better than implicit.')
 
 Tables
 ------
@@ -682,4 +700,3 @@ downloads http://sphinx-doc.org/markup/inline.html#referencing-downloadable-file
 http://reinout.vanrees.org/weblog/2009/10/30/restructured-text-cheat-sheet.html
 
 RST cheat sheet http://openalea.gforge.inria.fr/doc/openalea/doc/_build/html/source/sphinx/rest_syntax.html
-

--- a/source/index.rst
+++ b/source/index.rst
@@ -22,7 +22,6 @@ Second Section
 
 Second text.
 
-
 First Set of Documents
 ----------------------
 
@@ -57,4 +56,3 @@ Indices and tables
 
 * :ref:`genindex`
 * :ref:`search`
-


### PR DESCRIPTION
Switch from Sphinx 1.2.3 to 1.3.1, demonstrate code block captions,
add the _static directory and its empty file to prevent sphinx build
warnings, switch from old default theme to alabaster theme which also
prevents that warning.